### PR TITLE
Houdini.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To install plugin one has to take the following steps:
    Add the following section to this file.
 
     ```
-    HOUDINI_PATH = "/path/to/zync-houdini/;&"
+    HOUDINI_PATH = "$HOUDINI_PATH;/path/to/zync-houdini/;&"
     ```
 
     Be careful about preserving `;&` at the end. If you are using Windows make

--- a/python2.7libs/zync_houdini.py
+++ b/python2.7libs/zync_houdini.py
@@ -27,7 +27,7 @@ import zync
 import file_select_dialog
 
 
-__version__ = '1.0.6'
+__version__ = '1.0.7'
 
 
 class JobCreationError(Exception):


### PR DESCRIPTION
Hey,

This PR is also more a request to change how you install the plugins for Houdini. Currently you are overriding any environment set prior to launching Houdini. Use ```$HOUDINI_PATH``` will inherit the existing environment and append to it.

NOTE: I haven't tested this on OSX and Linux, so I don't know whether the path separator ```;``` needs to change per platform.